### PR TITLE
feat: Add core documentation files (AMI-248)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@amiable.dev**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,305 @@
+# Contributing to MIDIMon
+
+Thank you for your interest in contributing to MIDIMon! We welcome contributions of all kinds - from bug reports and documentation improvements to new features and hardware support.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Ways to Contribute](#ways-to-contribute)
+- [Development Setup](#development-setup)
+- [Coding Standards](#coding-standards)
+- [Pull Request Process](#pull-request-process)
+- [Testing Guidelines](#testing-guidelines)
+- [Communication](#communication)
+
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to conduct@amiable.dev.
+
+## Ways to Contribute
+
+### 🐛 Bug Reports
+
+Found a bug? Please open a [GitHub issue](https://github.com/amiable-dev/midimon/issues/new) with:
+- Clear description of the issue
+- Steps to reproduce
+- Expected vs actual behavior
+- System information (OS, Rust version, MIDI device)
+- Relevant log output (run with `DEBUG=1` for verbose logs)
+
+### 💡 Feature Requests
+
+Have an idea? We'd love to hear it! Open a [GitHub Discussion](https://github.com/amiable-dev/midimon/discussions/new?category=ideas) with:
+- Clear description of the proposed feature
+- Use cases and benefits
+- Potential implementation approaches (optional)
+- Alternatives considered (optional)
+
+### 📖 Documentation
+
+Documentation improvements are always welcome:
+- Fix typos or clarify existing docs
+- Add examples for common use cases
+- Improve API documentation
+- Write tutorials or guides
+- Translate documentation
+
+### 🔧 Code Contributions
+
+Ready to write code? Check out:
+- [Good First Issues](https://github.com/amiable-dev/midimon/labels/good-first-issue)
+- [Help Wanted](https://github.com/amiable-dev/midimon/labels/help-wanted)
+- Incomplete feature implementations
+
+### 🎹 Device Support
+
+Help us support more MIDI controllers:
+- Test MIDIMon with your device
+- Create device profiles (.ncmm3 or config templates)
+- Document device-specific quirks or features
+- Implement LED feedback for new devices
+
+## Development Setup
+
+### Prerequisites
+
+- **Rust** 1.70+ (install via [rustup](https://rustup.rs/))
+- **macOS** 10.15+ (Linux/Windows support planned)
+- **MIDI Controller** (optional for testing, required for LED feedback)
+- **Git** for version control
+
+### Setup Steps
+
+1. **Fork and Clone**
+   ```bash
+   git fork amiable-dev/midimon
+   git clone https://github.com/YOUR_USERNAME/midimon.git
+   cd midimon
+   ```
+
+2. **Build the Project**
+   ```bash
+   cargo build
+   ```
+
+3. **Run Tests**
+   ```bash
+   cargo test
+   ```
+
+4. **Run MIDIMon**
+   ```bash
+   # List available MIDI ports
+   cargo run --release
+
+   # Connect to a specific port
+   cargo run --release 2
+
+   # Enable debug logging
+   DEBUG=1 cargo run --release 2
+   ```
+
+5. **Create a Feature Branch**
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+## Coding Standards
+
+### Rust Style
+
+- Follow [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- Use `rustfmt` for formatting: `cargo fmt`
+- Use `clippy` for linting: `cargo clippy`
+- Maximum line length: 100 characters
+- Use meaningful variable names
+- Add comments for complex logic
+
+### Project Structure
+
+```
+src/
+├── main.rs              # Entry point, MIDI connection, event loop
+├── config.rs            # Configuration structures (TOML parsing)
+├── event_processor.rs   # MIDI event → Processed event
+├── mappings.rs          # Mapping engine
+├── actions.rs           # Action execution
+├── feedback.rs          # LED feedback trait
+├── mikro_leds.rs        # Maschine Mikro MK3 LED control
+├── midi_feedback.rs     # Generic MIDI LED fallback
+└── device_profile.rs    # NI profile parser
+```
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add support for MIDI Learn mode
+fix: resolve double-tap detection timing issue
+docs: update configuration examples
+test: add integration tests for velocity detection
+refactor: extract LED control to trait
+chore: update dependencies
+```
+
+### Documentation
+
+- Add doc comments (`///`) for public items
+- Include examples in doc comments where helpful
+- Update `README.md` if adding user-facing features
+- Update configuration documentation for new trigger/action types
+
+## Pull Request Process
+
+### Before Submitting
+
+1. **Ensure Tests Pass**
+   ```bash
+   cargo test
+   ```
+
+2. **Check Formatting**
+   ```bash
+   cargo fmt --check
+   ```
+
+3. **Run Clippy**
+   ```bash
+   cargo clippy -- -D warnings
+   ```
+
+4. **Update Documentation**
+   - Update `README.md` for user-facing changes
+   - Add doc comments for new public APIs
+   - Update configuration examples if needed
+
+5. **Test Manually**
+   - Test with a real MIDI device if possible
+   - Verify LED feedback works correctly
+   - Check configuration loading
+
+### Submitting
+
+1. **Push to Your Fork**
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+2. **Open Pull Request**
+   - Clear title following conventional commit format
+   - Description explaining what and why
+   - Link related issues
+   - Add screenshots/videos if applicable
+   - Check the box for "Allow edits from maintainers"
+
+3. **Respond to Review**
+   - Address reviewer comments
+   - Push updates to the same branch
+   - Request re-review when ready
+
+### PR Requirements
+
+- ✅ All tests pass (CI will verify)
+- ✅ Code follows style guidelines
+- ✅ Commits follow conventional commit format
+- ✅ Documentation updated
+- ✅ No unrelated changes
+- ✅ Squash commits if requested
+
+## Testing Guidelines
+
+### Test Coverage
+
+- Aim for 85%+ test coverage
+- Write unit tests for business logic
+- Write integration tests for event processing
+- Write E2E tests for critical workflows
+
+### Test Organization
+
+```rust
+// Unit tests in the same file
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_velocity_detection() {
+        // Test implementation
+    }
+}
+```
+
+### Running Tests
+
+```bash
+# All tests
+cargo test
+
+# Specific test
+cargo test test_velocity_detection
+
+# With output
+cargo test -- --nocapture
+
+# Coverage report
+cargo tarpaulin --workspace
+```
+
+### Test Checklist
+
+- [ ] Unit tests for new functions
+- [ ] Integration tests for event flows
+- [ ] Edge cases covered
+- [ ] Error conditions tested
+- [ ] Documentation examples tested
+
+## Communication
+
+### GitHub Discussions
+
+Use [Discussions](https://github.com/amiable-dev/midimon/discussions) for:
+- Questions about usage
+- Feature ideas and proposals
+- General community chat
+- Show & tell (your configurations, videos, etc.)
+
+### GitHub Issues
+
+Use [Issues](https://github.com/amiable-dev/midimon/issues) for:
+- Bug reports
+- Approved feature requests
+- Documentation improvements
+
+### Discord (Coming Soon)
+
+Real-time chat for:
+- Development questions
+- Collaboration
+- Community support
+
+### Email
+
+- **Security**: security@amiable.dev
+- **Code of Conduct**: conduct@amiable.dev
+- **General**: hello@amiable.dev
+
+## First-Time Contributors
+
+New to open source? No problem! Here's how to get started:
+
+1. **Look for Good First Issues**: We label beginner-friendly issues with [good-first-issue](https://github.com/amiable-dev/midimon/labels/good-first-issue)
+2. **Read the Docs**: Familiarize yourself with the project structure
+3. **Set Up Development**: Follow the development setup guide
+4. **Ask Questions**: Don't hesitate to ask in Discussions
+5. **Start Small**: Fix a typo, improve docs, or tackle a small bug
+6. **Learn and Grow**: Every contribution helps you learn
+
+## License
+
+By contributing to MIDIMon, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+
+---
+
+Thank you for contributing to MIDIMon! 🎹

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Amiable
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,393 @@
+# MIDIMon
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
+[![Build Status](https://github.com/amiable-dev/midimon/workflows/CI/badge.svg)](https://github.com/amiable-dev/midimon/actions)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://amiable-dev.github.io/midimon/)
+
+Transform MIDI controllers into advanced macro pads with velocity sensitivity, LED feedback, and visual configuration.
+
+![MIDIMon Demo](docs/images/hero-demo.gif)
+*Velocity-sensitive RGB LED feedback on Native Instruments Maschine Mikro MK3*
+
+## Features
+
+### Core Features
+- **Multi-mode operation** - Switch between different mapping sets
+- **Configurable mappings** - Easy TOML-based configuration
+- **Low latency** - Sub-millisecond response time
+- **Cross-platform** - Works on macOS, Linux, and Windows
+
+### Enhanced Event Detection
+- **Velocity Sensitivity** - Different actions for soft/medium/hard presses
+- **Long Press Detection** - Hold actions with configurable thresholds
+- **Double-Tap Detection** - Quick double-tap triggers
+- **Chord Detection** - Multiple pads pressed simultaneously
+- **Encoder Direction** - Clockwise/counter-clockwise detection
+- **Aftertouch Support** - Pressure-sensitive actions
+- **Pitch Bend Support** - Touch strip integration
+
+### LED Feedback System
+- **Visual Feedback** - Real-time LED feedback on supported devices
+- **Multiple Schemes** - Rainbow, pulse, breathing, reactive, and more
+- **Mode Indication** - Color-coded modes for easy identification
+- **Velocity Visualization** - LED brightness matches pad velocity
+- **HID Support** - Full RGB control for Maschine Mikro MK3
+- **MIDI LED** - Basic feedback for standard MIDI devices
+
+> 📖 **See [LED_FEEDBACK.md](LED_FEEDBACK.md) for complete LED system documentation**
+
+## Hardware Compatibility
+
+| Device | Status | LED Feedback | Notes |
+|--------|--------|--------------|-------|
+| Native Instruments Maschine Mikro MK3 | ✅ Full Support | RGB (HID) | Recommended |
+| Generic MIDI Controllers | ✅ Supported | Basic (MIDI) | Most features work |
+| Akai APC Mini | ⚠️ Untested | Basic (MIDI) | Should work |
+| Novation Launchpad | ⚠️ Untested | Basic (MIDI) | Should work |
+
+**Want to add support for your device?** See [CONTRIBUTING.md](CONTRIBUTING.md#device-support)
+
+## Installation
+
+### From Binary (Recommended)
+
+Download the latest release for your platform:
+- [macOS (Intel)](https://github.com/amiable-dev/midimon/releases/latest/download/midimon-macos-intel)
+- [macOS (Apple Silicon)](https://github.com/amiable-dev/midimon/releases/latest/download/midimon-macos-arm)
+
+```bash
+# Make it executable
+chmod +x midimon-*
+
+# Run
+./midimon-* 2  # Connect to MIDI port 2
+```
+
+### From Source
+
+```bash
+# Clone the repository
+git clone https://github.com/amiable-dev/midimon.git
+cd midimon
+
+# Build the project
+cargo build --release
+
+# Run the main application
+cargo run --release 2  # Connect to port 2 (Maschine Mikro MK3)
+```
+
+**Requirements:**
+- Rust 1.70+ ([Install via rustup](https://rustup.rs/))
+- macOS 10.15+ (Linux/Windows support planned)
+
+## Quick Start
+
+1. **Connect your MIDI controller** (e.g., Native Instruments Maschine Mikro MK3)
+2. **Install necessary drivers** (Native Instruments Controller Editor for NI devices)
+3. **Run the application**:
+   ```bash
+   cargo run --release [port_number]
+   ```
+4. **Press pads** to trigger macros!
+
+## Configuration
+
+Edit `config.toml` to customize your mappings. The enhanced configuration supports:
+
+### Basic Note Trigger
+```toml
+[[modes.mappings]]
+description = "Spotlight Search"
+[modes.mappings.trigger]
+type = "Note"
+note = 12
+velocity_min = 1  # Optional
+velocity_max = 127  # Optional
+[modes.mappings.action]
+type = "Keystroke"
+keys = "space"
+modifiers = ["cmd"]
+```
+
+### Velocity-Sensitive Actions
+```toml
+# Soft press
+[[modes.mappings]]
+description = "Volume Down (soft)"
+[modes.mappings.trigger]
+type = "VelocityRange"
+note = 13
+min_velocity = 1
+max_velocity = 40
+[modes.mappings.action]
+type = "VolumeControl"
+action = "Down"
+
+# Hard press
+[[modes.mappings]]
+description = "Volume Up (hard)"
+[modes.mappings.trigger]
+type = "VelocityRange"
+note = 13
+min_velocity = 80
+max_velocity = 127
+[modes.mappings.action]
+type = "VolumeControl"
+action = "Up"
+```
+
+### Long Press
+```toml
+[[modes.mappings]]
+description = "Quit App (long press)"
+[modes.mappings.trigger]
+type = "LongPress"
+note = 4
+min_duration_ms = 1500
+[modes.mappings.action]
+type = "Keystroke"
+keys = "q"
+modifiers = ["cmd"]
+```
+
+### Double-Tap
+```toml
+[[modes.mappings]]
+description = "Fullscreen (double tap)"
+[modes.mappings.trigger]
+type = "DoubleTap"
+note = 16
+max_interval_ms = 300
+[modes.mappings.action]
+type = "Keystroke"
+keys = "f"
+modifiers = ["ctrl", "cmd"]
+```
+
+### Chord Detection
+```toml
+[[modes.mappings]]
+description = "Force Quit (chord)"
+[modes.mappings.trigger]
+type = "NoteChord"
+notes = [8, 12]  # Both pads must be pressed
+max_interval_ms = 100
+[modes.mappings.action]
+type = "Keystroke"
+keys = "escape"
+modifiers = ["cmd", "option"]
+```
+
+### Encoder Actions
+```toml
+[[global_mappings]]
+description = "Volume Up"
+[global_mappings.trigger]
+type = "EncoderTurn"
+cc = 2
+direction = "Clockwise"
+[global_mappings.action]
+type = "VolumeControl"
+action = "Up"
+```
+
+## Diagnostic Tools
+
+### MIDI Diagnostic Tool
+Visualize all MIDI events from your controller:
+```bash
+cargo run --bin midi_diagnostic 2
+```
+
+Features:
+- Real-time event visualization
+- Velocity bars
+- Hold duration tracking
+- Beautiful colored output
+
+### Test MIDI Ports
+List all available MIDI devices:
+```bash
+cargo run --bin test_midi
+```
+
+## Action Types
+
+### Basic Actions
+- **Keystroke** - Simulate keyboard shortcuts
+- **Text** - Type text strings
+- **Launch** - Open applications
+- **Shell** - Execute shell commands
+- **Delay** - Add delays between actions
+- **MouseClick** - Simulate mouse clicks
+
+### Advanced Actions
+- **VolumeControl** - System volume control (Up/Down/Mute/Set)
+- **ModeChange** - Switch between mapping modes
+- **Sequence** - Chain multiple actions
+- **Repeat** - Repeat an action multiple times
+- **Conditional** - Execute based on conditions
+
+## Modes
+
+The system supports multiple modes, each with its own set of mappings:
+
+1. **Default Mode** - General productivity shortcuts
+2. **Development Mode** - Git commands, build tools
+3. **Media Mode** - Music and video controls
+4. **Custom Modes** - Create your own!
+
+Switch modes using:
+- Encoder rotation
+- Specific pad combinations
+- CC messages
+
+## Troubleshooting
+
+### MIDI Device Not Found
+1. Check if device is connected: `system_profiler SPUSBDataType | grep -i mikro`
+2. Install necessary drivers (e.g., Native Instruments Controller Editor)
+3. Check Audio MIDI Setup: `open -a "Audio MIDI Setup"`
+
+### High Latency
+- Build in release mode: `cargo build --release`
+- Close unnecessary applications
+- Check CPU usage
+
+### Events Not Triggering
+- Run diagnostic tool to verify MIDI events
+- Check config.toml for correct note numbers
+- Verify velocity/duration thresholds
+
+## Advanced Configuration
+
+### Timing Settings
+```toml
+[advanced_settings]
+chord_timeout_ms = 50        # Max time between notes for chord
+double_tap_timeout_ms = 300  # Max time between taps
+hold_threshold_ms = 2000     # Time before hold is detected
+```
+
+### Conditional Actions
+```toml
+[[modes.mappings]]
+description = "Context-aware action"
+[modes.mappings.trigger]
+type = "Note"
+note = 20
+[modes.mappings.action]
+type = "Conditional"
+[modes.mappings.action.condition]
+type = "AppRunning"
+app_name = "Terminal"
+[modes.mappings.action.then_action]
+type = "Keystroke"
+keys = "c"
+modifiers = ["ctrl"]
+[modes.mappings.action.else_action]
+type = "Launch"
+app = "Terminal"
+```
+
+## Development
+
+### Project Structure
+```
+midimon/
+├── src/
+│   ├── main.rs           # Main application
+│   ├── config.rs         # Configuration structures
+│   ├── actions.rs        # Action execution
+│   ├── mappings.rs       # Trigger mapping engine
+│   ├── event_processor.rs # Enhanced event processing
+│   └── bin/
+│       ├── test_midi.rs  # MIDI port tester
+│       └── midi_diagnostic.rs # Diagnostic tool
+├── config.toml           # User configuration
+└── Cargo.toml           # Dependencies
+```
+
+### Adding New Trigger Types
+1. Add to `Trigger` enum in `config.rs`
+2. Add to `ProcessedEvent` enum in `event_processor.rs`
+3. Update `EventProcessor::process()` to detect the trigger
+4. Update `MappingEngine::trigger_matches_processed()` to handle matching
+
+### Adding New Action Types
+1. Add to `ActionConfig` enum in `config.rs`
+2. Add to `Action` enum in `actions.rs`
+3. Update `ActionExecutor::execute()` to handle the action
+
+## Performance
+
+- **Response Time**: < 1ms typical latency
+- **Memory Usage**: 5-10MB
+- **CPU Usage**: < 1% idle, < 5% active
+- **Binary Size**: ~3-5MB (release build with LTO)
+
+## Contributing
+
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
+- How to report bugs
+- How to propose features
+- Development setup guide
+- Coding standards
+- Pull request process
+
+Check out [good first issues](https://github.com/amiable-dev/midimon/labels/good-first-issue) to get started.
+
+## Documentation
+
+- **[Full Documentation](https://amiable-dev.github.io/midimon/)** - Complete user guide
+- **[LED Feedback System](LED_FEEDBACK.md)** - LED control documentation
+- **[Configuration Reference](docs/configuration.md)** - TOML configuration guide
+- **[API Documentation](https://docs.rs/midimon)** - Rust API docs
+
+## Community & Support
+
+- **[Discussions](https://github.com/amiable-dev/midimon/discussions)** - Ask questions, share configs
+- **[Issues](https://github.com/amiable-dev/midimon/issues)** - Bug reports, feature requests
+- **[Security](SECURITY.md)** - Security vulnerability reporting
+
+## Roadmap
+
+### Current: Phase 0 - v0.1.0-monolithic
+- ✅ Single-binary implementation with all core features
+- ✅ Velocity sensitivity, long press, double-tap, chords
+- ✅ Full RGB LED feedback for Maschine Mikro MK3
+- ✅ Multi-mode operation
+- ✅ Device profile support (.ncmm3)
+
+### Phase 1 - v0.2.0
+- 📋 Complete feature specifications
+- 📋 85%+ test coverage
+- 📋 Comprehensive documentation
+
+### Phase 2 - v1.0.0
+- 🔮 Monorepo migration (midimon-core, midimon-daemon, midimon-gui)
+- 🔮 Background daemon with menu bar
+- 🔮 Config hot-reload
+
+### Phase 3 - v1.5.0
+- 🔮 Tauri-based visual configurator
+- 🔮 MIDI Learn mode
+- 🔮 Per-app profiles
+
+See [docs/implementation-roadmap.md](docs/implementation-roadmap.md) for full roadmap.
+
+## License
+
+MIDIMon is licensed under the [MIT License](LICENSE).
+
+Copyright (c) 2025 Amiable
+
+## Credits
+
+Built with:
+- [midir](https://github.com/Boddlnagg/midir) - MIDI I/O
+- [enigo](https://github.com/enigo-rs/enigo) - Input simulation
+- [colored](https://github.com/mackwic/colored) - Terminal colors
+- [serde](https://serde.rs/) - Serialization

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,114 @@
+# Security Policy
+
+## Supported Versions
+
+We release security updates for the following versions of MIDIMon:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| 0.1.x   | :white_check_mark: |
+| < 0.1.0 | :x:                |
+
+## Reporting a Vulnerability
+
+We take the security of MIDIMon seriously. If you discover a security vulnerability, please follow these steps:
+
+### 1. DO NOT Disclose Publicly
+
+Please do not open a public GitHub issue or discussion about the vulnerability. This helps protect users while we work on a fix.
+
+### 2. Report Privately
+
+Send details of the vulnerability to: **security@amiable.dev**
+
+Include in your report:
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact assessment
+- Suggested fix (if you have one)
+- Your name/handle for acknowledgment (optional)
+
+### 3. Response Timeline
+
+- **Initial Response**: Within 48 hours
+- **Status Update**: Within 7 days with assessment and estimated fix timeline
+- **Fix Released**: Critical issues within 14 days, others within 30 days
+- **Public Disclosure**: After fix is released and users have had time to update (typically 7-14 days)
+
+### 4. Security Update Process
+
+1. We'll confirm the vulnerability and assess its severity
+2. We'll develop a fix in a private repository
+3. We'll release a patch version with the fix
+4. We'll publish a security advisory with details and mitigation steps
+5. We'll credit the reporter (if desired) in our security hall of fame
+
+## Known Security Considerations
+
+### HID Device Access
+
+MIDIMon requires HID device access to control LED feedback on MIDI controllers. On macOS, this requires:
+- Input Monitoring permissions granted in System Settings
+- User consent for device access
+
+**Mitigation**: Users should only grant permissions to official releases from trusted sources.
+
+### Shell Command Execution
+
+MIDIMon can execute shell commands as part of action mappings (e.g., launching applications, volume control). This is a powerful feature but requires careful configuration.
+
+**Best Practices**:
+- Review configuration files before loading them from untrusted sources
+- Use absolute paths for shell commands
+- Avoid running MIDIMon with elevated privileges unless necessary
+- Validate all user-provided configuration inputs
+
+### Configuration File Loading
+
+MIDIMon loads TOML configuration files that define action mappings.
+
+**Best Practices**:
+- Only load configuration files from trusted sources
+- Review configurations before applying them
+- Keep backups of working configurations
+- Use version control for configuration files
+
+### Native Instruments Controller Editor Profiles
+
+MIDIMon can load .ncmm3 profile files from Native Instruments Controller Editor.
+
+**Best Practices**:
+- Only load profiles from official Native Instruments sources or trusted creators
+- XML parsing is done with a memory-safe Rust library (quick-xml)
+
+## Security Hall of Fame
+
+We acknowledge and thank the following security researchers for responsibly disclosing vulnerabilities:
+
+*(No reports yet - be the first!)*
+
+## Public Disclosure Policy
+
+- We believe in coordinated disclosure to protect users
+- Security patches are released before public disclosure
+- We'll work with reporters to agree on disclosure timeline
+- We'll credit reporters in release notes and this document (with permission)
+
+## PGP Key
+
+For encrypted vulnerability reports, use our PGP key:
+
+```
+(PGP key to be added if needed)
+```
+
+## Additional Resources
+
+- [GitHub Security Advisories](https://github.com/amiable-dev/midimon/security/advisories)
+- [SECURITY.md Guidelines](https://docs.github.com/en/code-security/security-advisories)
+- [Common Weakness Enumeration (CWE)](https://cwe.mitre.org/)
+
+---
+
+**Last Updated**: 2025-11-11


### PR DESCRIPTION
## Summary
Adds essential open source documentation files required for public repository.

## Changes
- ✅ Add MIT License (copyright 2025 Amiable)
- ✅ Add Contributor Covenant Code of Conduct v2.1
- ✅ Add comprehensive CONTRIBUTING.md with development guide
- ✅ Add SECURITY.md with vulnerability reporting process
- ✅ Enhance README.md with:
  - Project badges (license, build, docs)
  - Hardware compatibility table
  - Installation instructions (binary + source)
  - Roadmap overview
  - Community links

## Related Issues
- Closes AMI-248

## Checklist
- [x] All documentation files created
- [x] README enhanced with badges and links
- [x] License is valid MIT license
- [x] Code of Conduct based on Contributor Covenant 2.1
- [x] SECURITY.md has clear reporting process
- [x] CONTRIBUTING.md provides clear guidelines
- [x] All internal links work correctly
- [x] Follows standard open source conventions

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>