### PR TITLE
Add documentation site infrastructure with mdBook (AMI-258)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,49 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs-site/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
+
+      - name: Build documentation
+        run: cd docs-site && mdbook build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs-site/book
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs-site/book.toml
+++ b/docs-site/book.toml
@@ -1,0 +1,42 @@
+[book]
+title = "MIDIMon Documentation"
+authors = ["Amiable Dev"]
+language = "en"
+multilingual = false
+src = "src"
+description = "Transform MIDI controllers into advanced macro pads with RGB feedback and timing-based triggers"
+
+[build]
+build-dir = "book"
+create-missing = true
+
+[output.html]
+default-theme = "light"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/amiable-dev/midimon"
+git-repository-icon = "fa-github"
+edit-url-template = "https://github.com/amiable-dev/midimon/edit/main/docs-site/src/{path}"
+site-url = "/midimon/"
+cname = ""
+
+[output.html.fold]
+enable = true
+level = 0
+
+[output.html.search]
+enable = true
+limit-results = 30
+teaser-word-count = 30
+use-boolean-and = true
+boost-title = 2
+boost-hierarchy = 1
+boost-paragraph = 1
+expand = true
+heading-split-level = 3
+
+[output.html.playground]
+editable = false
+copyable = true
+copy-js = true
+line-numbers = false
+runnable = false

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -1,0 +1,64 @@
+# Summary
+
+[Introduction](introduction.md)
+
+# Installation
+
+- [macOS Installation](installation/macos.md)
+- [Linux Installation](installation/linux.md)
+- [Windows Installation](installation/windows.md)
+- [Building from Source](installation/building.md)
+
+# Getting Started
+
+- [Quick Start](getting-started/quick-start.md)
+- [Your First Mapping](getting-started/first-mapping.md)
+- [MIDI Learn](getting-started/midi-learn.md)
+- [Understanding Modes](getting-started/modes.md)
+
+# Configuration
+
+- [Configuration Overview](configuration/overview.md)
+- [Triggers Reference](configuration/triggers.md)
+- [Actions Reference](configuration/actions.md)
+- [Modes System](configuration/modes.md)
+- [LED Feedback](configuration/led-feedback.md)
+- [Device Profiles](configuration/device-profiles.md)
+- [Configuration Examples](configuration/examples.md)
+
+# Reference
+
+- [Trigger Types](reference/trigger-types.md)
+- [Action Types](reference/action-types.md)
+- [CLI Commands](reference/cli-commands.md)
+- [Config File Schema](reference/config-schema.md)
+- [Environment Variables](reference/environment.md)
+
+# Device Support
+
+- [Compatibility Matrix](devices/compatibility.md)
+- [Maschine Mikro MK3](devices/mikro-mk3.md)
+- [Generic MIDI Controllers](devices/generic-midi.md)
+- [Creating Device Profiles](devices/creating-profiles.md)
+
+# Development
+
+- [Development Setup](development/setup.md)
+- [Architecture Overview](development/architecture.md)
+- [Contributing Guide](development/contributing.md)
+- [Testing Guide](development/testing.md)
+- [Release Process](development/release-process.md)
+
+# Troubleshooting
+
+- [Common Issues](troubleshooting/common-issues.md)
+- [FAQ](troubleshooting/faq.md)
+- [Diagnostic Tools](troubleshooting/diagnostics.md)
+- [Performance](troubleshooting/performance.md)
+
+# Resources
+
+- [Changelog](resources/changelog.md)
+- [Roadmap](resources/roadmap.md)
+- [Community](resources/community.md)
+- [Support](resources/support.md)

--- a/docs-site/src/configuration/actions.md
+++ b/docs-site/src/configuration/actions.md
@@ -1,0 +1,17 @@
+# Actions Reference
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/configuration/device-profiles.md
+++ b/docs-site/src/configuration/device-profiles.md
@@ -1,0 +1,17 @@
+# Device Profiles
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/configuration/examples.md
+++ b/docs-site/src/configuration/examples.md
@@ -1,0 +1,17 @@
+# Configuration Examples
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/configuration/led-feedback.md
+++ b/docs-site/src/configuration/led-feedback.md
@@ -1,0 +1,17 @@
+# LED Feedback
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/configuration/modes.md
+++ b/docs-site/src/configuration/modes.md
@@ -1,0 +1,17 @@
+# Modes System
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/configuration/overview.md
+++ b/docs-site/src/configuration/overview.md
@@ -1,0 +1,17 @@
+# Configuration Overview
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/configuration/triggers.md
+++ b/docs-site/src/configuration/triggers.md
@@ -1,0 +1,17 @@
+# Triggers Reference
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/development/architecture.md
+++ b/docs-site/src/development/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Overview
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/development/contributing.md
+++ b/docs-site/src/development/contributing.md
@@ -1,0 +1,17 @@
+# Contributing Guide
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/development/release-process.md
+++ b/docs-site/src/development/release-process.md
@@ -1,0 +1,17 @@
+# Release Process
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/development/setup.md
+++ b/docs-site/src/development/setup.md
@@ -1,0 +1,17 @@
+# Development Setup
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/development/testing.md
+++ b/docs-site/src/development/testing.md
@@ -1,0 +1,17 @@
+# Testing Guide
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/devices/compatibility.md
+++ b/docs-site/src/devices/compatibility.md
@@ -1,0 +1,17 @@
+# Compatibility Matrix
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/devices/creating-profiles.md
+++ b/docs-site/src/devices/creating-profiles.md
@@ -1,0 +1,17 @@
+# Creating Device Profiles
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/devices/generic-midi.md
+++ b/docs-site/src/devices/generic-midi.md
@@ -1,0 +1,17 @@
+# Generic MIDI Controllers
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/devices/mikro-mk3.md
+++ b/docs-site/src/devices/mikro-mk3.md
@@ -1,0 +1,17 @@
+# Maschine Mikro MK3
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/getting-started/first-mapping.md
+++ b/docs-site/src/getting-started/first-mapping.md
@@ -1,0 +1,17 @@
+# Your First Mapping
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/getting-started/midi-learn.md
+++ b/docs-site/src/getting-started/midi-learn.md
@@ -1,0 +1,17 @@
+# MIDI Learn
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/getting-started/modes.md
+++ b/docs-site/src/getting-started/modes.md
@@ -1,0 +1,17 @@
+# Understanding Modes
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/getting-started/quick-start.md
+++ b/docs-site/src/getting-started/quick-start.md
@@ -1,0 +1,17 @@
+# Quick Start
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/installation/building.md
+++ b/docs-site/src/installation/building.md
@@ -1,0 +1,17 @@
+# Building from Source
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/installation/linux.md
+++ b/docs-site/src/installation/linux.md
@@ -1,0 +1,17 @@
+# Linux Installation
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/installation/macos.md
+++ b/docs-site/src/installation/macos.md
@@ -1,0 +1,17 @@
+# macOS Installation
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/installation/windows.md
+++ b/docs-site/src/installation/windows.md
@@ -1,0 +1,17 @@
+# Windows Installation
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/introduction.md
+++ b/docs-site/src/introduction.md
@@ -1,0 +1,98 @@
+# Introduction
+
+**Transform any MIDI controller into an advanced, context-aware macro pad with professional-grade feedback and timing-based triggers.**
+
+MIDIMon is a powerful Rust-based MIDI controller mapping system that goes beyond simple note-to-key bindings. It provides velocity sensitivity, long press detection, double-tap, chord recognition, and full RGB LED feedback for modern workflows.
+
+## Key Features
+
+### Core Capabilities
+
+- **4 Core Triggers**: Note, Velocity Range, Encoder, Control Change
+- **5 Advanced Triggers**: Long Press, Double-Tap, Chord, Aftertouch, Pitch Bend
+- **10 Action Types**: Keystroke, Text, Launch, Shell, Volume Control, and more
+- **10 LED Schemes**: Reactive, Rainbow, Pulse, Breathing, and custom patterns
+- **Multi-Mode System**: Switch between mapping sets on the fly
+- **Device Profile Support**: Load Native Instruments Controller Editor configurations
+
+### Performance
+
+- Response latency: **<1ms** typical
+- Memory footprint: **5-10MB**
+- CPU usage: **<1%** idle, **<5%** active
+- Binary size: **3-5MB** (optimized)
+
+## Who is MIDIMon For?
+
+### Music Producers
+Control DAWs, plugins, and effects with velocity-sensitive, multi-layer mappings.
+
+### Software Developers
+Streamline coding workflows with mode-based hotkey systems and build tool shortcuts.
+
+### Content Creators
+Manage streaming, recording, and editing with physical MIDI controls.
+
+### Power Users
+Replace expensive macro pads with affordable MIDI controllers that do more.
+
+## Why MIDIMon?
+
+Unlike existing MIDI mapping tools, MIDIMon provides:
+
+- **Advanced Timing**: Long press, double-tap, chord detection out of the box
+- **Velocity Sensitivity**: Different actions for soft/medium/hard pad hits
+- **Full RGB Feedback**: Not just on/off LEDs, but animated schemes and reactive color
+- **Modern Architecture**: Fast Rust core, hot-reload config (coming soon), cross-platform
+- **Open Source**: Fully customizable, extensible, community-driven
+
+## Quick Example
+
+```toml
+# Press pad lightly for copy, hard for paste
+[[modes.mappings]]
+trigger = { type = "VelocityRange", note = 36 }
+soft = { action = { type = "Keystroke", key = "C", modifiers = ["Cmd"] } }
+hard = { action = { type = "Keystroke", key = "V", modifiers = ["Cmd"] } }
+
+# Hold for 2 seconds to open terminal
+[[modes.mappings]]
+trigger = { type = "LongPress", note = 37, duration_ms = 2000 }
+action = { type = "Launch", path = "/Applications/Utilities/Terminal.app" }
+```
+
+## Platform Support
+
+- **macOS**: Full support (11+ Big Sur, Apple Silicon + Intel)
+- **Linux**: Planned for Phase 4 (Q4 2025)
+- **Windows**: Planned for Phase 4 (Q4 2025)
+
+## Device Compatibility
+
+- **Fully Supported**: Native Instruments Maschine Mikro MK3 (RGB LEDs, HID access)
+- **MIDI-Only Support**: Any USB MIDI controller with basic LED feedback
+- **Coming Soon**: Launchpad, APC Mini, Korg nanoKontrol, and more
+
+## Get Started
+
+Ready to dive in? Check out the [Quick Start Guide](getting-started/quick-start.md) or [Installation Instructions](installation/macos.md).
+
+## Project Status
+
+MIDIMon is currently at **v0.1.0-monolithic** (pre-1.0 software). The core features are stable and production-ready, but the API may change before v1.0.0.
+
+See the [Roadmap](resources/roadmap.md) for planned features and timeline.
+
+## Community
+
+- **GitHub**: [https://github.com/amiable-dev/midimon](https://github.com/amiable-dev/midimon)
+- **Discussions**: [https://github.com/amiable-dev/midimon/discussions](https://github.com/amiable-dev/midimon/discussions)
+- **Issues**: [https://github.com/amiable-dev/midimon/issues](https://github.com/amiable-dev/midimon/issues)
+
+## License
+
+MIDIMon is open source software licensed under the **MIT License**. See [LICENSE](https://github.com/amiable-dev/midimon/blob/main/LICENSE) for details.
+
+---
+
+**Next**: [Install MIDIMon](installation/macos.md) | [Quick Start](getting-started/quick-start.md)

--- a/docs-site/src/reference/action-types.md
+++ b/docs-site/src/reference/action-types.md
@@ -1,0 +1,17 @@
+# Action Types
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/reference/cli-commands.md
+++ b/docs-site/src/reference/cli-commands.md
@@ -1,0 +1,17 @@
+# CLI Commands
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/reference/config-schema.md
+++ b/docs-site/src/reference/config-schema.md
@@ -1,0 +1,17 @@
+# Config File Schema
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/reference/environment.md
+++ b/docs-site/src/reference/environment.md
@@ -1,0 +1,17 @@
+# Environment Variables
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/reference/trigger-types.md
+++ b/docs-site/src/reference/trigger-types.md
@@ -1,0 +1,17 @@
+# Trigger Types
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/resources/changelog.md
+++ b/docs-site/src/resources/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+See the main [CHANGELOG.md](https://github.com/amiable-dev/midimon/blob/main/CHANGELOG.md) in the repository.

--- a/docs-site/src/resources/community.md
+++ b/docs-site/src/resources/community.md
@@ -1,0 +1,9 @@
+# Community
+
+Join the MIDIMon community:
+
+- **GitHub Discussions**: [https://github.com/amiable-dev/midimon/discussions](https://github.com/amiable-dev/midimon/discussions)
+- **Issues**: [https://github.com/amiable-dev/midimon/issues](https://github.com/amiable-dev/midimon/issues)
+- **Discord**: Coming soon!
+
+See [GOVERNANCE.md](https://github.com/amiable-dev/midimon/blob/main/GOVERNANCE.md) for community structure.

--- a/docs-site/src/resources/roadmap.md
+++ b/docs-site/src/resources/roadmap.md
@@ -1,0 +1,3 @@
+# Roadmap
+
+See the main [ROADMAP.md](https://github.com/amiable-dev/midimon/blob/main/ROADMAP.md) in the repository.

--- a/docs-site/src/resources/support.md
+++ b/docs-site/src/resources/support.md
@@ -1,0 +1,3 @@
+# Support
+
+See the main [SUPPORT.md](https://github.com/amiable-dev/midimon/blob/main/SUPPORT.md) for getting help.

--- a/docs-site/src/troubleshooting/common-issues.md
+++ b/docs-site/src/troubleshooting/common-issues.md
@@ -1,0 +1,17 @@
+# Common Issues
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/troubleshooting/diagnostics.md
+++ b/docs-site/src/troubleshooting/diagnostics.md
@@ -1,0 +1,17 @@
+# Diagnostic Tools
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/troubleshooting/faq.md
+++ b/docs-site/src/troubleshooting/faq.md
@@ -1,0 +1,17 @@
+# FAQ
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).

--- a/docs-site/src/troubleshooting/performance.md
+++ b/docs-site/src/troubleshooting/performance.md
@@ -1,0 +1,17 @@
+# Performance
+
+> **Note**: This section is under development and will be completed in Phase 1 (Q1 2025).
+> 
+> For now, please refer to:
+> - [README.md](https://github.com/amiable-dev/midimon/blob/main/README.md)
+> - [CLAUDE.md](https://github.com/amiable-dev/midimon/blob/main/CLAUDE.md)
+> - [GitHub Discussions](https://github.com/amiable-dev/midimon/discussions)
+
+## Coming Soon
+
+This page will cover:
+- TBD
+
+---
+
+**Help Wanted**: We're looking for contributors to help write documentation. See [Contributing Guide](../development/contributing.md).


### PR DESCRIPTION
## Summary

Implements complete mdBook-based documentation site structure with GitHub Pages deployment.

- mdBook configuration with search, folding, and GitHub integration
- Complete table of contents (40+ pages across 8 sections)
- Placeholder pages for all documentation sections
- GitHub Actions workflow for auto-deployment
- Ready for content writing in AMI-251

## Test Plan

- [x] mdBook configuration validated
- [x] SUMMARY.md structure complete
- [x] All placeholder pages created
- [x] GitHub Actions workflow syntax validated
- [x] Directory structure follows best practices

Closes AMI-258

🤖 Generated with [Claude Code](https://claude.com/claude-code)